### PR TITLE
Add CLI support for npm package info and owner details

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,32 @@
 # cnpm-cli-test
+
+This CLI tool allows you to interact with the npm registry directly from your command line. Here are the commands you can use:
+
+## Commands
+
+- `cnpm info <package>`: Print package info from npm registry.
+- `cnpm owner ls <package>`: Print owner details of a package from npm registry.
+
+## Installation
+
+To use this CLI, clone the repository and install the dependencies:
+
+```bash
+git clone https://github.com/atian25/cnpm-cli-test.git
+cd cnpm-cli-test
+npm install
+```
+
+## Usage
+
+To get information about a package, use:
+
+```bash
+cnpm info <package>
+```
+
+To list the owners of a package, use:
+
+```bash
+cnpm owner ls <package>
+```

--- a/cli.js
+++ b/cli.js
@@ -1,0 +1,34 @@
+const { program } = require('commander');
+const axios = require('axios');
+
+program
+  .version('1.0.0')
+  .description('A CLI tool for fetching npm package info and owner details');
+
+program
+  .command('info <package>')
+  .description('Print package info from npm registry')
+  .action(async (package) => {
+    try {
+      const response = await axios.get(`https://registry.npmjs.org/${package}`);
+      console.log(response.data);
+    } catch (error) {
+      console.error('Error fetching package info:', error.message);
+    }
+  });
+
+program
+  .command('owner <package>')
+  .description('Print owner details of a package from npm registry')
+  .action(async (package) => {
+    try {
+      const response = await axios.get(`https://registry.npmjs.org/${package}`);
+      const maintainers = response.data.maintainers;
+      console.log(`Owners of ${package}:`);
+      maintainers.forEach(maintainer => console.log(maintainer.name));
+    } catch (error) {
+      console.error('Error fetching owner details:', error.message);
+    }
+  });
+
+program.parse(process.argv);

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "cnpm-cli-test",
+  "version": "1.0.0",
+  "description": "A CLI tool for fetching npm package info and owner details",
+  "main": "cli.js",
+  "scripts": {
+    "start": "node cli.js",
+    "info": "node cli.js info",
+    "owner": "node cli.js owner"
+  },
+  "keywords": [
+    "npm",
+    "cli",
+    "package",
+    "info",
+    "owner"
+  ],
+  "author": "Your Name",
+  "license": "ISC",
+  "dependencies": {
+    "axios": "^0.21.1",
+    "commander": "^7.2.0"
+  }
+}


### PR DESCRIPTION
Related to #1

Implements a CLI tool for fetching npm package info and owner details, and updates the README.md with usage instructions.

- **Adds `cli.js`**: Implements the CLI interface using Node.js, including commands to print package info and owner details from the npm registry using `axios` and `commander`.
- **Initializes `package.json`**: Sets up a new Node.js project with dependencies on `axios` for HTTP requests and `commander` for CLI commands. Defines scripts for running the CLI commands.
- **Updates `README.md`**: Provides detailed instructions on how to install, setup, and use the new CLI commands for fetching package info and owner details from the npm registry.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/atian25/cnpm-cli-test/issues/1?shareId=261f0bb1-803b-4874-af64-820741a5b378).